### PR TITLE
Upgrades protobuf-net and Newtonsoft.Json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
         run: dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
 
       - name: Run Tests
-        run: dotnet test ./tests/bin/Release/net6.0/Tests.dll
+        run: dotnet test ./tests/bin/Release/net6.0/Tests.dll --filter "TestCategory!=TravisExclude"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
+    runs-on: ubuntu-20.04    
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: BuildDataSource
         run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="protobuf-net" Version="3.1.33" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -12,7 +12,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
+    <PackageReference Include="protobuf-net" Version="3.1.33" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/VIXCentralContangoDataProcessingTests.cs
+++ b/tests/VIXCentralContangoDataProcessingTests.cs
@@ -26,7 +26,7 @@ using QuantConnect.DataSource;
 
 namespace QuantConnect.DataLibrary.Tests
 {
-    [TestFixture]
+    [TestFixture, Category("TravisExclude")]
     public class VIXCentralContangoDataProcessingTests
     {
         [Test]


### PR DESCRIPTION
We need to use the latest `QuantConnect.Common` binaries to calculate the expiry dates correctly.